### PR TITLE
[workflows] daily-benchmark: Bump Ubuntu version to 22.04

### DIFF
--- a/.github/workflows/daily-benchmark.yml
+++ b/.github/workflows/daily-benchmark.yml
@@ -11,7 +11,7 @@ jobs:
         disk:
           - 1
           - 0
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -19,7 +19,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.x
+        go-version: 1.20.x
 
     - name: Setup dependencies
       run: |


### PR DESCRIPTION
That's the version used by the tests and by the PPA too.