### PR TITLE
Replace gopkg.in/yaml.v2 with github.com/goccy/go-yaml

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - 1.20.x
+          - 1.21.x
         os:
           - ubuntu-22.04
     runs-on: ${{ matrix.os }}
@@ -67,7 +67,7 @@ jobs:
         echo "Read results:"
         head -n 5 /tmp/cowsql-benchmark/127.0.0.1:9001/results/0-query-*
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: cowsql-benchmark-${{ matrix.os }}-${{ matrix.go }}
         path: /tmp/cowsql-benchmark/127.0.0.1:9001/results/*

--- a/.github/workflows/daily-benchmark.yml
+++ b/.github/workflows/daily-benchmark.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18.x
+        go-version: 1.21.x
 
     - name: Setup dependencies
       run: |
@@ -40,7 +40,7 @@ jobs:
         echo "Read results:"
         head -n 5 /tmp/cowsql-benchmark/127.0.0.1:9001/results/0-query-*
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: cowsql-daily-benchmark
         path: /tmp/cowsql-benchmark/127.0.0.1:9001/results/*

--- a/app/example_test.go
+++ b/app/example_test.go
@@ -2,7 +2,6 @@ package app_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/cowsql/go-cowsql/app"
@@ -16,7 +15,7 @@ import (
 //
 // The very first node has always the same ID (cowsql.BootstrapID).
 func Example() {
-	dir, err := ioutil.TempDir("", "cowsql-app-example-")
+	dir, err := os.MkdirTemp("", "cowsql-app-example-")
 	if err != nil {
 		return
 	}
@@ -55,19 +54,19 @@ func Example() {
 //
 // Each additional node will be automatically assigned a unique ID.
 func ExampleWithCluster() {
-	dir1, err := ioutil.TempDir("", "cowsql-app-example-")
+	dir1, err := os.MkdirTemp("", "cowsql-app-example-")
 	if err != nil {
 		return
 	}
 	defer os.RemoveAll(dir1)
 
-	dir2, err := ioutil.TempDir("", "cowsql-app-example-")
+	dir2, err := os.MkdirTemp("", "cowsql-app-example-")
 	if err != nil {
 		return
 	}
 	defer os.RemoveAll(dir2)
 
-	dir3, err := ioutil.TempDir("", "cowsql-app-example-")
+	dir3, err := os.MkdirTemp("", "cowsql-app-example-")
 	if err != nil {
 		return
 	}

--- a/app/files.go
+++ b/app/files.go
@@ -2,11 +2,10 @@ package app
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
-	"gopkg.in/yaml.v2"
+	"github.com/goccy/go-yaml"
 	"github.com/google/renameio"
 )
 
@@ -41,7 +40,7 @@ func fileExists(dir, file string) (bool, error) {
 func fileWrite(dir, file string, data []byte) error {
 	path := filepath.Join(dir, file)
 
-	if err := renameio.WriteFile(path, data, 0600); err != nil {
+	if err := renameio.WriteFile(path, data, 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", file, err)
 	}
 
@@ -64,7 +63,7 @@ func fileMarshal(dir, file string, object interface{}) error {
 func fileUnmarshal(dir, file string, object interface{}) error {
 	path := filepath.Join(dir, file)
 
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("read %s: %w", file, err)
 	}

--- a/app/tls.go
+++ b/app/tls.go
@@ -27,7 +27,7 @@ import (
 // then load the resulting key pair and pool with:
 //
 //   cert, _ := tls.LoadX509KeyPair("cluster.crt", "cluster.key")
-//   data, _ := ioutil.ReadFile("cluster.crt")
+//   data, _ := os.ReadFile("cluster.crt")
 //   pool := x509.NewCertPool()
 //   pool.AppendCertsFromPEM(data)
 //

--- a/benchmark/benchmark_test.go
+++ b/benchmark/benchmark_test.go
@@ -3,14 +3,12 @@ package benchmark_test
 import (
 	"context"
 	"database/sql"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/cowsql/go-cowsql/app"
 	"github.com/cowsql/go-cowsql/benchmark"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -19,21 +17,35 @@ const (
 	addr3 = "127.0.0.1:9013"
 )
 
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func requireErrorf(t *testing.T, err error, msg string, args ...any) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf(msg, args...)
+	}
+}
+
 func bmSetup(t *testing.T, addr string, join []string) (string, *app.App, *sql.DB, func()) {
 	t.Helper()
 
-	dir, err := ioutil.TempDir("", "cowsql-app-test-")
-	require.NoError(t, err)
+	dir, err := os.MkdirTemp("", "cowsql-app-test-")
+	requireNoError(t, err)
 
 	app, err := app.New(dir, app.WithAddress(addr), app.WithCluster(join))
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	readyCtx, cancel := context.WithTimeout(context.Background(), time.Duration(3)*time.Second)
 	err = app.Ready(readyCtx)
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	db, err := app.Open(context.Background(), "benchmark")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	cleanups := func() {
 		os.RemoveAll(dir)
@@ -48,7 +60,7 @@ func bmRun(t *testing.T, bm *benchmark.Benchmark, app *app.App, db *sql.DB) {
 	ch := make(chan os.Signal)
 
 	err := bm.Run(ch)
-	require.NoError(t, err)
+	requireNoError(t, err)
 }
 
 // Create a Benchmark with default values.
@@ -62,7 +74,7 @@ func TestNew_Default(t *testing.T) {
 		dir,
 		benchmark.WithCluster([]string{addr1}),
 		benchmark.WithDuration(1))
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	bmRun(t, bm, app, db)
 }
@@ -79,7 +91,7 @@ func TestNew_KvReadWrite(t *testing.T) {
 		benchmark.WithCluster([]string{addr1}),
 		benchmark.WithDuration(1),
 		benchmark.WithWorkload("KvReadWrite"))
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	bmRun(t, bm, app, db)
 }
@@ -99,7 +111,7 @@ func TestNew_ClusteredKvReadWrite(t *testing.T) {
 		dir,
 		benchmark.WithCluster([]string{addr1, addr2, addr3}),
 		benchmark.WithDuration(2))
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	bmRun(t, bm, app, db)
 }
@@ -117,9 +129,9 @@ func TestNew_ClusteredTimeout(t *testing.T) {
 		dir,
 		benchmark.WithCluster([]string{addr1, addr2}),
 		benchmark.WithClusterTimeout(2))
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	ch := make(chan os.Signal)
 	err = bm.Run(ch)
-	require.Errorf(t, err, "Timed out waiting for cluster: context deadline exceeded")
+	requireErrorf(t, err, "Timed out waiting for cluster: context deadline exceeded")
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -3,17 +3,48 @@ package client_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
+	"reflect"
 	"testing"
 	"time"
 
 	cowsql "github.com/cowsql/go-cowsql"
 	"github.com/cowsql/go-cowsql/client"
 	"github.com/cowsql/go-cowsql/internal/protocol"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
+
+var (
+	assertLen     = requireLen
+	assertNoError = requireNoError
+)
+
+func assertTrue(t *testing.T, ok bool) {
+	t.Helper()
+	if !ok {
+		t.Fatal(ok)
+	}
+}
+
+func requireLen(t *testing.T, x any, l int) {
+	t.Helper()
+	v := reflect.ValueOf(x)
+	if l != v.Len() {
+		t.Fatal()
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual interface{}) {
+	t.Helper()
+	if expected == nil || actual == nil {
+		if expected != actual {
+			t.Fatal(expected, actual)
+		}
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatal(expected, actual)
+	}
+}
 
 func TestClient_Leader(t *testing.T) {
 	node, cleanup := newNode(t)
@@ -23,14 +54,14 @@ func TestClient_Leader(t *testing.T) {
 	defer cancel()
 
 	client, err := client.New(ctx, node.BindAddress())
-	require.NoError(t, err)
+	requireNoError(t, err)
 	defer client.Close()
 
 	leader, err := client.Leader(context.Background())
-	require.NoError(t, err)
+	requireNoError(t, err)
 
-	assert.Equal(t, leader.ID, uint64(1))
-	assert.Equal(t, leader.Address, "@1001")
+	assertEqual(t, leader.ID, uint64(1))
+	assertEqual(t, leader.Address, "@1001")
 }
 
 func TestClient_Dump(t *testing.T) {
@@ -41,7 +72,7 @@ func TestClient_Dump(t *testing.T) {
 	defer cancel()
 
 	client, err := client.New(ctx, node.BindAddress())
-	require.NoError(t, err)
+	requireNoError(t, err)
 	defer client.Close()
 
 	// Open a database and create a test table.
@@ -55,25 +86,25 @@ func TestClient_Dump(t *testing.T) {
 
 	p := client.Protocol()
 	err = p.Call(ctx, &request, &response)
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	db, err := protocol.DecodeDb(&response)
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	protocol.EncodeExecSQLV0(&request, uint64(db), "CREATE TABLE foo (n INT)", nil)
 
 	err = p.Call(ctx, &request, &response)
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	files, err := client.Dump(ctx, "test.db")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
-	require.Len(t, files, 2)
-	assert.Equal(t, "test.db", files[0].Name)
-	assert.Equal(t, 4096, len(files[0].Data))
+	requireLen(t, files, 2)
+	assertEqual(t, "test.db", files[0].Name)
+	assertEqual(t, 4096, len(files[0].Data))
 
-	assert.Equal(t, "test.db-wal", files[1].Name)
-	assert.Equal(t, 8272, len(files[1].Data))
+	assertEqual(t, "test.db-wal", files[1].Name)
+	assertEqual(t, 8272, len(files[1].Data))
 }
 
 func TestClient_Cluster(t *testing.T) {
@@ -84,16 +115,16 @@ func TestClient_Cluster(t *testing.T) {
 	defer cancel()
 
 	cli, err := client.New(ctx, node.BindAddress())
-	require.NoError(t, err)
+	requireNoError(t, err)
 	defer cli.Close()
 
 	servers, err := cli.Cluster(context.Background())
-	require.NoError(t, err)
+	requireNoError(t, err)
 
-	assert.Len(t, servers, 1)
-	assert.Equal(t, servers[0].ID, uint64(1))
-	assert.Equal(t, servers[0].Address, "@1001")
-	assert.Equal(t, servers[0].Role, client.Voter)
+	assertLen(t, servers, 1)
+	assertEqual(t, servers[0].ID, uint64(1))
+	assertEqual(t, servers[0].Address, "@1001")
+	assertEqual(t, servers[0].Role, client.Voter)
 }
 
 func TestClient_Transfer(t *testing.T) {
@@ -104,30 +135,29 @@ func TestClient_Transfer(t *testing.T) {
 	defer cancel()
 
 	cli, err := client.New(ctx, node1.BindAddress())
-	require.NoError(t, err)
+	requireNoError(t, err)
 	defer cli.Close()
 
 	node2, cleanup := addNode(t, cli, 2)
 	defer cleanup()
 
 	err = cli.Assign(context.Background(), 2, client.Voter)
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	err = cli.Transfer(context.Background(), 2)
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	leader, err := cli.Leader(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, leader.ID, uint64(2))
+	requireNoError(t, err)
+	assertEqual(t, leader.ID, uint64(2))
 
 	cli, err = client.New(ctx, node2.BindAddress())
-	require.NoError(t, err)
+	requireNoError(t, err)
 	defer cli.Close()
 
 	leader, err = cli.Leader(context.Background())
-	require.NoError(t, err)
-	assert.Equal(t, leader.ID, uint64(2))
-
+	requireNoError(t, err)
+	assertEqual(t, leader.ID, uint64(2))
 }
 
 func TestClient_Describe(t *testing.T) {
@@ -138,22 +168,22 @@ func TestClient_Describe(t *testing.T) {
 	defer cancel()
 
 	cli, err := client.New(ctx, node.BindAddress())
-	require.NoError(t, err)
+	requireNoError(t, err)
 	defer cli.Close()
 
 	metadata, err := cli.Describe(context.Background())
-	require.NoError(t, err)
+	requireNoError(t, err)
 
-	assert.Equal(t, uint64(0), metadata.FailureDomain)
-	assert.Equal(t, uint64(0), metadata.Weight)
+	assertEqual(t, uint64(0), metadata.FailureDomain)
+	assertEqual(t, uint64(0), metadata.Weight)
 
-	require.NoError(t, cli.Weight(context.Background(), 123))
+	requireNoError(t, cli.Weight(context.Background(), 123))
 
 	metadata, err = cli.Describe(context.Background())
-	require.NoError(t, err)
+	requireNoError(t, err)
 
-	assert.Equal(t, uint64(0), metadata.FailureDomain)
-	assert.Equal(t, uint64(123), metadata.Weight)
+	assertEqual(t, uint64(0), metadata.FailureDomain)
+	assertEqual(t, uint64(123), metadata.Weight)
 }
 
 func newNode(t *testing.T) (*cowsql.Node, func()) {
@@ -163,13 +193,13 @@ func newNode(t *testing.T) (*cowsql.Node, func()) {
 	id := uint64(1)
 	address := fmt.Sprintf("@%d", id+1000)
 	node, err := cowsql.New(uint64(1), address, dir, cowsql.WithBindAddress(address))
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	err = node.Start()
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	cleanup := func() {
-		require.NoError(t, node.Close())
+		requireNoError(t, node.Close())
 		dirCleanup()
 	}
 
@@ -185,10 +215,10 @@ func addNode(t *testing.T, cli *client.Client, id uint64) (*cowsql.Node, func())
 
 	address := fmt.Sprintf("@%d", id+1000)
 	node, err := cowsql.New(id, address, dir, cowsql.WithBindAddress(address))
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	err = node.Start()
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	info := client.NodeInfo{
 		ID:      id,
@@ -197,10 +227,10 @@ func addNode(t *testing.T, cli *client.Client, id uint64) (*cowsql.Node, func())
 	}
 
 	err = cli.Add(ctx, info)
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	cleanup := func() {
-		require.NoError(t, node.Close())
+		requireNoError(t, node.Close())
 		dirCleanup()
 	}
 
@@ -211,15 +241,15 @@ func addNode(t *testing.T, cli *client.Client, id uint64) (*cowsql.Node, func())
 func newDir(t *testing.T) (string, func()) {
 	t.Helper()
 
-	dir, err := ioutil.TempDir("", "cowsql-replication-test-")
-	assert.NoError(t, err)
+	dir, err := os.MkdirTemp("", "cowsql-replication-test-")
+	assertNoError(t, err)
 
 	cleanup := func() {
 		_, err := os.Stat(dir)
 		if err != nil {
-			assert.True(t, os.IsNotExist(err))
+			assertTrue(t, os.IsNotExist(err))
 		} else {
-			assert.NoError(t, os.RemoveAll(dir))
+			assertNoError(t, os.RemoveAll(dir))
 		}
 	}
 

--- a/client/leader_test.go
+++ b/client/leader_test.go
@@ -8,8 +8,14 @@ import (
 
 	cowsql "github.com/cowsql/go-cowsql"
 	"github.com/cowsql/go-cowsql/client"
-	"github.com/stretchr/testify/require"
 )
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestMembership(t *testing.T) {
 	n := 3
@@ -22,12 +28,12 @@ func TestMembership(t *testing.T) {
 		dir, cleanup := newDir(t)
 		defer cleanup()
 		node, err := cowsql.New(id, address, dir, cowsql.WithBindAddress(address))
-		require.NoError(t, err)
+		requireNoError(t, err)
 		nodes[i] = node
 		infos[i].ID = id
 		infos[i].Address = address
 		err = node.Start()
-		require.NoError(t, err)
+		requireNoError(t, err)
 		defer node.Close()
 	}
 
@@ -38,9 +44,9 @@ func TestMembership(t *testing.T) {
 	store.Set(context.Background(), []client.NodeInfo{infos[0]})
 
 	client, err := client.FindLeader(ctx, store)
-	require.NoError(t, err)
+	requireNoError(t, err)
 	defer client.Close()
 
 	err = client.Add(ctx, infos[1])
-	require.NoError(t, err)
+	requireNoError(t, err)
 }

--- a/client/store.go
+++ b/client/store.go
@@ -2,12 +2,11 @@ package client
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"sync"
 
+	"github.com/goccy/go-yaml"
 	"github.com/google/renameio"
-	"gopkg.in/yaml.v2"
 
 	"github.com/cowsql/go-cowsql/internal/protocol"
 )
@@ -45,7 +44,7 @@ func NewYamlNodeStore(path string) (*YamlNodeStore, error) {
 			return nil, err
 		}
 	} else {
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}
@@ -82,7 +81,7 @@ func (s *YamlNodeStore) Set(ctx context.Context, servers []NodeInfo) error {
 		return err
 	}
 
-	if err := renameio.WriteFile(s.path, data, 0600); err != nil {
+	if err := renameio.WriteFile(s.path, data, 0o600); err != nil {
 		return err
 	}
 

--- a/client/store_test.go
+++ b/client/store_test.go
@@ -1,3 +1,4 @@
+//go:build !nosqlite3
 // +build !nosqlite3
 
 package client_test
@@ -10,39 +11,51 @@ import (
 	cowsql "github.com/cowsql/go-cowsql"
 	"github.com/cowsql/go-cowsql/client"
 	"github.com/cowsql/go-cowsql/driver"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
+
+func assertEqualError(t *testing.T, err error, msg string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal()
+	}
+
+	if err.Error() != msg {
+		t.Fatal(err)
+	}
+}
 
 // Exercise setting and getting servers in a DatabaseNodeStore created with
 // DefaultNodeStore.
 func TestDefaultNodeStore(t *testing.T) {
 	// Create a new default store.
 	store, err := client.DefaultNodeStore(":memory:")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	// Set and get some targets.
 	err = store.Set(context.Background(), []client.NodeInfo{
-		{Address: "1.2.3.4:666"}, {Address: "5.6.7.8:666"}},
+		{Address: "1.2.3.4:666"}, {Address: "5.6.7.8:666"},
+	},
 	)
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	servers, err := store.Get(context.Background())
-	assert.Equal(t, []client.NodeInfo{
+	assertEqual(t, []client.NodeInfo{
 		{ID: uint64(1), Address: "1.2.3.4:666"},
-		{ID: uint64(1), Address: "5.6.7.8:666"}},
+		{ID: uint64(1), Address: "5.6.7.8:666"},
+	},
 		servers)
 
 	// Set and get some new targets.
 	err = store.Set(context.Background(), []client.NodeInfo{
 		{Address: "1.2.3.4:666"}, {Address: "9.9.9.9:666"},
 	})
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	servers, err = store.Get(context.Background())
-	assert.Equal(t, []client.NodeInfo{
+	assertEqual(t, []client.NodeInfo{
 		{ID: uint64(1), Address: "1.2.3.4:666"},
-		{ID: uint64(1), Address: "9.9.9.9:666"}},
+		{ID: uint64(1), Address: "9.9.9.9:666"},
+	},
 		servers)
 
 	// Setting duplicate targets returns an error and the change is not
@@ -50,12 +63,13 @@ func TestDefaultNodeStore(t *testing.T) {
 	err = store.Set(context.Background(), []client.NodeInfo{
 		{Address: "1.2.3.4:666"}, {Address: "1.2.3.4:666"},
 	})
-	assert.EqualError(t, err, "failed to insert server 1.2.3.4:666: UNIQUE constraint failed: servers.address")
+	assertEqualError(t, err, "failed to insert server 1.2.3.4:666: UNIQUE constraint failed: servers.address")
 
 	servers, err = store.Get(context.Background())
-	assert.Equal(t, []client.NodeInfo{
+	assertEqual(t, []client.NodeInfo{
 		{ID: uint64(1), Address: "1.2.3.4:666"},
-		{ID: uint64(1), Address: "9.9.9.9:666"}},
+		{ID: uint64(1), Address: "9.9.9.9:666"},
+	},
 		servers)
 }
 
@@ -64,18 +78,18 @@ func TestConfigMultiThread(t *testing.T) {
 	defer cleanup()
 
 	err := cowsql.ConfigMultiThread()
-	assert.EqualError(t, err, "SQLite is already initialized")
+	assertEqualError(t, err, "SQLite is already initialized")
 }
 
 func dummyDBSetup(t *testing.T) func() {
 	store := client.NewInmemNodeStore()
 	driver, err := driver.New(store)
-	require.NoError(t, err)
+	requireNoError(t, err)
 	sql.Register("dummy", driver)
 	db, err := sql.Open("dummy", "test.db")
-	require.NoError(t, err)
+	requireNoError(t, err)
 	cleanup := func() {
-		require.NoError(t, db.Close())
+		requireNoError(t, db.Close())
 	}
 	return cleanup
 }

--- a/cmd/cowsql-demo/cowsql-demo.go
+++ b/cmd/cowsql-demo/cowsql-demo.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -38,7 +38,7 @@ func main() {
 Complete documentation is available at https://github.com/cowsql/go-cowsql`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dir := filepath.Join(dir, db)
-			if err := os.MkdirAll(dir, 0755); err != nil {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
 				return errors.Wrapf(err, "can't create %s", dir)
 			}
 			logFunc := func(l client.LogLevel, format string, a ...interface{}) {
@@ -59,7 +59,7 @@ Complete documentation is available at https://github.com/cowsql/go-cowsql`,
 				if err != nil {
 					return err
 				}
-				data, err := ioutil.ReadFile(crt)
+				data, err := os.ReadFile(crt)
 				if err != nil {
 					return err
 				}
@@ -100,7 +100,7 @@ Complete documentation is available at https://github.com/cowsql/go-cowsql`,
 					break
 				case "PUT":
 					result = "done"
-					value, _ := ioutil.ReadAll(r.Body)
+					value, _ := io.ReadAll(r.Body)
 					if _, err := db.Exec(update, key, string(value[:])); err != nil {
 						result = fmt.Sprintf("Error: %s", err.Error())
 					}

--- a/cmd/cowsql/cowsql.go
+++ b/cmd/cowsql/cowsql.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -69,7 +68,7 @@ func main() {
 					return err
 				}
 
-				data, err := ioutil.ReadFile(crt)
+				data, err := os.ReadFile(crt)
 				if err != nil {
 					return err
 				}

--- a/driver/integration_test.go
+++ b/driver/integration_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"reflect"
 	"testing"
 	"time"
 
@@ -12,74 +13,157 @@ import (
 	"github.com/cowsql/go-cowsql/client"
 	"github.com/cowsql/go-cowsql/driver"
 	"github.com/cowsql/go-cowsql/logging"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // https://sqlite.org/rescode.html#constraint_unique
 const SQLITE_CONSTRAINT_UNIQUE = 2067
+
+var (
+	requireNoError = assertNoError
+	requireTrue    = assertTrue
+	requireEqual   = assertEqual
+)
+
+func assertTrue(t *testing.T, ok bool) {
+	t.Helper()
+	if !ok {
+		t.Fatal(ok)
+	}
+}
+
+func assertNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual any) {
+	t.Helper()
+	if expected == nil || actual == nil {
+		if expected != actual {
+			t.Fatal(expected, actual)
+		}
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatal(expected, actual)
+	}
+}
+
+func assertEqualError(t *testing.T, err error, msg string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal()
+	}
+
+	if err.Error() != msg {
+		t.Fatal(err)
+	}
+}
+
+func requireNil(t *testing.T, x interface{}) {
+	t.Helper()
+
+	if x != nil {
+		v := reflect.ValueOf(x)
+		switch v.Kind() {
+		case reflect.Chan, reflect.Func,
+			reflect.Interface, reflect.Map,
+			reflect.Ptr, reflect.Slice, reflect.UnsafePointer:
+			if !v.IsNil() {
+				t.Fatal(x)
+			}
+		}
+	}
+}
+
+func requireNotNil(t *testing.T, x interface{}) {
+	t.Helper()
+
+	if x == nil {
+		t.Fatal(x)
+	}
+
+	v := reflect.ValueOf(x)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func,
+		reflect.Interface, reflect.Map,
+		reflect.Ptr, reflect.Slice, reflect.UnsafePointer:
+		if v.IsNil() {
+			t.Fatal(x)
+		}
+	}
+}
+
+func assertError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal()
+	}
+}
 
 func TestIntegration_DatabaseSQL(t *testing.T) {
 	db, _, cleanup := newDB(t, 3)
 	defer cleanup()
 
 	tx, err := db.Begin()
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	_, err = tx.Exec(`
 CREATE TABLE test  (n INT, s TEXT);
 CREATE TABLE test2 (n INT, t DATETIME DEFAULT CURRENT_TIMESTAMP)
 `)
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	stmt, err := tx.Prepare("INSERT INTO test(n, s) VALUES(?, ?)")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	_, err = stmt.Exec(int64(123), "hello")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
-	require.NoError(t, stmt.Close())
+	requireNoError(t, stmt.Close())
 
 	_, err = tx.Exec("INSERT INTO test2(n) VALUES(?)", int64(456))
-	require.NoError(t, err)
+	requireNoError(t, err)
 
-	require.NoError(t, tx.Commit())
+	requireNoError(t, tx.Commit())
 
 	tx, err = db.Begin()
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	rows, err := tx.Query("SELECT n, s FROM test")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	for rows.Next() {
 		var n int64
 		var s string
 
-		require.NoError(t, rows.Scan(&n, &s))
+		requireNoError(t, rows.Scan(&n, &s))
 
-		assert.Equal(t, int64(123), n)
-		assert.Equal(t, "hello", s)
+		assertEqual(t, int64(123), n)
+		assertEqual(t, "hello", s)
 	}
 
-	require.NoError(t, rows.Err())
-	require.NoError(t, rows.Close())
+	requireNoError(t, rows.Err())
+	requireNoError(t, rows.Close())
 
 	rows, err = tx.Query("SELECT n, t FROM test2")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	for rows.Next() {
 		var n int64
 		var s time.Time
 
-		require.NoError(t, rows.Scan(&n, &s))
+		requireNoError(t, rows.Scan(&n, &s))
 
-		assert.Equal(t, int64(456), n)
+		assertEqual(t, int64(456), n)
 	}
 
-	require.NoError(t, rows.Err())
-	require.NoError(t, rows.Close())
+	requireNoError(t, rows.Err())
+	requireNoError(t, rows.Close())
 
-	require.NoError(t, tx.Rollback())
+	requireNoError(t, tx.Rollback())
 }
 
 func TestIntegration_ConstraintError(t *testing.T) {
@@ -87,15 +171,15 @@ func TestIntegration_ConstraintError(t *testing.T) {
 	defer cleanup()
 
 	_, err := db.Exec("CREATE TABLE test (n INT, UNIQUE (n))")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	_, err = db.Exec("INSERT INTO test (n) VALUES (1)")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	_, err = db.Exec("INSERT INTO test (n) VALUES (1)")
 	if err, ok := err.(driver.Error); ok {
-		assert.Equal(t, SQLITE_CONSTRAINT_UNIQUE, err.Code)
-		assert.Equal(t, "UNIQUE constraint failed: test.n", err.Message)
+		assertEqual(t, SQLITE_CONSTRAINT_UNIQUE, err.Code)
+		assertEqual(t, "UNIQUE constraint failed: test.n", err.Message)
 	} else {
 		t.Fatalf("expected diver error, got %+v", err)
 	}
@@ -110,10 +194,10 @@ func TestIntegration_ExecBindError(t *testing.T) {
 	defer cancel()
 
 	_, err := db.ExecContext(ctx, "CREATE TABLE test (n INT)")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	_, err = db.ExecContext(ctx, "INSERT INTO test(n) VALUES(1)", 1)
-	assert.EqualError(t, err, "bind parameters")
+	assertEqualError(t, err, "bind parameters")
 }
 
 func TestIntegration_QueryBindError(t *testing.T) {
@@ -125,7 +209,7 @@ func TestIntegration_QueryBindError(t *testing.T) {
 	defer cancel()
 
 	_, err := db.QueryContext(ctx, "SELECT 1", 1)
-	assert.EqualError(t, err, "bind parameters")
+	assertEqualError(t, err, "bind parameters")
 }
 
 func TestIntegration_LargeQuery(t *testing.T) {
@@ -133,50 +217,50 @@ func TestIntegration_LargeQuery(t *testing.T) {
 	defer cleanup()
 
 	tx, err := db.Begin()
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	_, err = tx.Exec("CREATE TABLE test (n INT)")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	stmt, err := tx.Prepare("INSERT INTO test(n) VALUES(?)")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	for i := 0; i < 512; i++ {
 		_, err = stmt.Exec(int64(i))
-		require.NoError(t, err)
+		requireNoError(t, err)
 	}
 
-	require.NoError(t, stmt.Close())
+	requireNoError(t, stmt.Close())
 
-	require.NoError(t, tx.Commit())
+	requireNoError(t, tx.Commit())
 
 	tx, err = db.Begin()
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	rows, err := tx.Query("SELECT n FROM test")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	columns, err := rows.Columns()
-	require.NoError(t, err)
+	requireNoError(t, err)
 
-	assert.Equal(t, []string{"n"}, columns)
+	assertEqual(t, []string{"n"}, columns)
 
 	count := 0
 	for i := 0; rows.Next(); i++ {
 		var n int64
 
-		require.NoError(t, rows.Scan(&n))
+		requireNoError(t, rows.Scan(&n))
 
-		assert.Equal(t, int64(i), n)
+		assertEqual(t, int64(i), n)
 		count++
 	}
 
-	require.NoError(t, rows.Err())
-	require.NoError(t, rows.Close())
+	requireNoError(t, rows.Err())
+	requireNoError(t, rows.Close())
 
-	assert.Equal(t, count, 512)
+	assertEqual(t, count, 512)
 
-	require.NoError(t, tx.Rollback())
+	requireNoError(t, tx.Rollback())
 }
 
 // Build a 2-node cluster, kill one node and recover the other.
@@ -185,7 +269,7 @@ func TestIntegration_Recover(t *testing.T) {
 	defer cleanup()
 
 	_, err := db.Exec("CREATE TABLE test (n INT)")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	helpers[0].Close()
 	helpers[1].Close()
@@ -193,7 +277,7 @@ func TestIntegration_Recover(t *testing.T) {
 	helpers[0].Create()
 
 	infos := []client.NodeInfo{{ID: 1, Address: "@1"}}
-	require.NoError(t, helpers[0].Node.Recover(infos))
+	requireNoError(t, helpers[0].Node.Recover(infos))
 
 	helpers[0].Start()
 
@@ -201,10 +285,10 @@ func TestIntegration_Recover(t *testing.T) {
 	// such table", because the replication hooks are not triggered and the
 	// barrier is not applied.
 	_, err = db.Exec("CREATE TABLE test2 (n INT)")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	_, err = db.Exec("INSERT INTO test(n) VALUES(1)")
-	require.NoError(t, err)
+	requireNoError(t, err)
 }
 
 // The db.Ping() method can be used to wait until there is a stable leader.
@@ -217,18 +301,18 @@ func TestIntegration_PingOnlyWorksOnceLeaderElected(t *testing.T) {
 	// Ping returns an error, since the cluster is not available.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	assert.Error(t, db.PingContext(ctx))
+	assertError(t, db.PingContext(ctx))
 
 	helpers[0].Create()
 	helpers[0].Start()
 
 	// Ping now returns no error, since the cluster is available.
-	assert.NoError(t, db.Ping())
+	assertNoError(t, db.Ping())
 
 	// If leadership is lost after the first successful call, Ping() still
 	// returns no error.
 	helpers[0].Close()
-	assert.NoError(t, db.Ping())
+	assertNoError(t, db.Ping())
 }
 
 func TestIntegration_HighAvailability(t *testing.T) {
@@ -236,7 +320,7 @@ func TestIntegration_HighAvailability(t *testing.T) {
 	defer cleanup()
 
 	_, err := db.Exec("CREATE TABLE test (n INT)")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	// Shutdown all three nodes.
 	helpers[0].Close()
@@ -253,7 +337,7 @@ func TestIntegration_HighAvailability(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	_, err = db.Exec("INSERT INTO test(n) VALUES(1)")
-	require.NoError(t, err)
+	requireNoError(t, err)
 }
 
 func TestIntegration_LeadershipTransfer(t *testing.T) {
@@ -261,13 +345,13 @@ func TestIntegration_LeadershipTransfer(t *testing.T) {
 	defer cleanup()
 
 	_, err := db.Exec("CREATE TABLE test (n INT)")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	cli := helpers[0].Client()
-	require.NoError(t, cli.Transfer(context.Background(), 2))
+	requireNoError(t, cli.Transfer(context.Background(), 2))
 
 	_, err = db.Exec("INSERT INTO test(n) VALUES(1)")
-	require.NoError(t, err)
+	requireNoError(t, err)
 }
 
 func TestIntegration_LeadershipTransfer_Tx(t *testing.T) {
@@ -275,18 +359,18 @@ func TestIntegration_LeadershipTransfer_Tx(t *testing.T) {
 	defer cleanup()
 
 	_, err := db.Exec("CREATE TABLE test (n INT)")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	cli := helpers[0].Client()
-	require.NoError(t, cli.Transfer(context.Background(), 2))
+	requireNoError(t, cli.Transfer(context.Background(), 2))
 
 	tx, err := db.Begin()
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	_, err = tx.Query("SELECT * FROM test")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
-	require.NoError(t, tx.Commit())
+	requireNoError(t, tx.Commit())
 }
 
 func TestOptions(t *testing.T) {
@@ -304,7 +388,7 @@ func TestOptions(t *testing.T) {
 		driver.WithAttemptTimeout(5*time.Second),
 		driver.WithRetryLimit(0),
 	)
-	require.NoError(t, err)
+	requireNoError(t, err)
 }
 
 func newDB(t *testing.T, n int) (*sql.DB, []*nodeHelper, func()) {
@@ -322,12 +406,12 @@ func newDBWithInfos(t *testing.T, infos []client.NodeInfo) (*sql.DB, []*nodeHelp
 
 	store := client.NewInmemNodeStore()
 
-	require.NoError(t, store.Set(context.Background(), infos))
+	requireNoError(t, store.Set(context.Background(), infos))
 
 	log := logging.Test(t)
 
 	driver, err := driver.New(store, driver.WithLogFunc(log))
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	driverName := fmt.Sprintf("cowsql-integration-test-%d", driversCount)
 	sql.Register(driverName, driver)
@@ -335,10 +419,10 @@ func newDBWithInfos(t *testing.T, infos []client.NodeInfo) (*sql.DB, []*nodeHelp
 	driversCount++
 
 	db, err := sql.Open(driverName, "test.db")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	cleanup := func() {
-		require.NoError(t, db.Close())
+		requireNoError(t, db.Close())
 		helpersCleanup()
 	}
 
@@ -377,25 +461,25 @@ func newNodeHelper(t *testing.T, id uint64, address string) *nodeHelper {
 
 func (h *nodeHelper) Client() *client.Client {
 	client, err := client.New(context.Background(), h.Node.BindAddress())
-	require.NoError(h.t, err)
+	requireNoError(h.t, err)
 	return client
 }
 
 func (h *nodeHelper) Create() {
 	var err error
-	require.Nil(h.t, h.Node)
+	requireNil(h.t, h.Node)
 	h.Node, err = cowsql.New(h.ID, h.Address, h.Dir, cowsql.WithBindAddress(h.Address))
-	require.NoError(h.t, err)
+	requireNoError(h.t, err)
 }
 
 func (h *nodeHelper) Start() {
-	require.NotNil(h.t, h.Node)
-	require.NoError(h.t, h.Node.Start())
+	requireNotNil(h.t, h.Node)
+	requireNoError(h.t, h.Node.Start())
 }
 
 func (h *nodeHelper) Close() {
-	require.NotNil(h.t, h.Node)
-	require.NoError(h.t, h.Node.Close())
+	requireNotNil(h.t, h.Node)
+	requireNoError(h.t, h.Node.Close())
 	h.Node = nil
 }
 
@@ -403,7 +487,7 @@ func (h *nodeHelper) cleanup() {
 	if h.Node != nil {
 		h.Close()
 	}
-	require.NoError(h.t, os.RemoveAll(h.Dir))
+	requireNoError(h.t, os.RemoveAll(h.Dir))
 }
 
 func newNodeHelpers(t *testing.T, infos []client.NodeInfo) ([]*nodeHelper, func()) {
@@ -419,7 +503,7 @@ func newNodeHelpers(t *testing.T, infos []client.NodeInfo) ([]*nodeHelper, func(
 			client := helpers[0].Client()
 			defer client.Close()
 
-			require.NoError(t, client.Add(context.Background(), infos[i]))
+			requireNoError(t, client.Add(context.Background(), infos[i]))
 		}
 	}
 
@@ -439,26 +523,26 @@ func TestIntegration_ColumnTypeName(t *testing.T) {
 	defer cleanup()
 
 	_, err := db.Exec("CREATE TABLE test (n INT, UNIQUE (n))")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	_, err = db.Exec("INSERT INTO test (n) VALUES (1)")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	rows, err := db.Query("SELECT n FROM test")
-	require.NoError(t, err)
+	requireNoError(t, err)
 	defer rows.Close()
 
 	types, err := rows.ColumnTypes()
-	require.NoError(t, err)
+	requireNoError(t, err)
 
-	assert.Equal(t, "INTEGER", types[0].DatabaseTypeName())
+	assertEqual(t, "INTEGER", types[0].DatabaseTypeName())
 
-	require.True(t, rows.Next())
+	requireTrue(t, rows.Next())
 	var n int64
 	err = rows.Scan(&n)
-	require.NoError(t, err)
+	requireNoError(t, err)
 
-	assert.Equal(t, int64(1), n)
+	assertEqual(t, int64(1), n)
 }
 
 func TestIntegration_SqlNullTime(t *testing.T) {
@@ -466,22 +550,24 @@ func TestIntegration_SqlNullTime(t *testing.T) {
 	defer cleanup()
 
 	_, err := db.Exec("CREATE TABLE test (tm DATETIME)")
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	// Insert sql.NullTime into DB
 	var t1 sql.NullTime
 	res, err := db.Exec("INSERT INTO test (tm) VALUES (?)", t1)
-	require.NoError(t, err)
+	requireNoError(t, err)
 
 	n, err := res.RowsAffected()
-	require.NoError(t, err)
-	assert.EqualValues(t, n, 1)
+	requireNoError(t, err)
+	if n != 1 {
+		t.Fatal(n, 1)
+	}
 
 	// Retrieve inserted sql.NullTime from DB
 	row := db.QueryRow("SELECT tm FROM test LIMIT 1")
 	var t2 sql.NullTime
 	err = row.Scan(&t2)
-	require.NoError(t, err)
+	requireNoError(t, err)
 
-	assert.Equal(t, t1, t2)
+	assertEqual(t, t1, t2)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,19 +1,22 @@
 module github.com/cowsql/go-cowsql
 
-// This is to maintain the ppa package on focal
-go 1.13
+go 1.21.13
 
 require (
 	github.com/Rican7/retry v0.3.0
+	github.com/goccy/go-yaml v1.17.1
 	github.com/google/renameio v1.0.1
-	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/mattn/go-sqlite3 v1.14.7
 	github.com/peterh/liner v1.2.1
-	github.com/pierrec/lz4/v4 v4.1.18 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.2.1
-	github.com/stretchr/testify v1.7.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22
-	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/mattn/go-runewidth v0.0.13 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -59,7 +59,6 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -74,6 +73,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=
+github.com/goccy/go-yaml v1.17.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -172,10 +173,8 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -201,13 +200,10 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/peterh/liner v1.2.1 h1:O4BlKaq/LWu6VRWmol4ByWfzx6MfXc5Op5HETyIy5yg=
 github.com/peterh/liner v1.2.1/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=
-github.com/pierrec/lz4/v4 v4.1.18 h1:xaKrnTkyoqfh1YItXl56+6KJNVYWlEEPuAQW9xsplYQ=
-github.com/pierrec/lz4/v4 v4.1.18/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -235,7 +231,6 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -570,17 +565,14 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -6,7 +6,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -237,7 +236,7 @@ func (s *Shell) processDump(ctx context.Context, line string) (string, error) {
 
 	for _, file := range files {
 		path := filepath.Join(dir, file.Name)
-		err := ioutil.WriteFile(path, file.Data, 0600)
+		err := os.WriteFile(path, file.Data, 0o600)
 		if err != nil {
 			return "NOK", fmt.Errorf("WriteFile failed on path %s", path)
 		}

--- a/logging/level_test.go
+++ b/logging/level_test.go
@@ -1,18 +1,31 @@
 package logging_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/cowsql/go-cowsql/logging"
-	"github.com/stretchr/testify/assert"
 )
 
+func assertEqual(t *testing.T, expected, actual any) {
+	t.Helper()
+	if expected == nil || actual == nil {
+		if expected != actual {
+			t.Fatal(expected, actual)
+		}
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatal(expected, actual)
+	}
+}
+
 func TestLevel_String(t *testing.T) {
-	assert.Equal(t, "DEBUG", logging.Debug.String())
-	assert.Equal(t, "INFO", logging.Info.String())
-	assert.Equal(t, "WARN", logging.Warn.String())
-	assert.Equal(t, "ERROR", logging.Error.String())
+	assertEqual(t, "DEBUG", logging.Debug.String())
+	assertEqual(t, "INFO", logging.Info.String())
+	assertEqual(t, "WARN", logging.Warn.String())
+	assertEqual(t, "ERROR", logging.Error.String())
 
 	unknown := logging.Level(666)
-	assert.Equal(t, "UNKNOWN", unknown.String())
+	assertEqual(t, "UNKNOWN", unknown.String())
 }


### PR DESCRIPTION
gopkg.in/yaml.v2/v3 is not active and incus is basing yaml on github.com/goccy/go-yaml. And remove stretchr/testify dependency since it depends on yaml.v3.