### PR TITLE
Replace github.com/pkg/errors with native error wrapping

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,7 +1,7 @@
 ;;; Directory Local Variables
 ;;; For more information see (info "(emacs) Directory Variables")
-((go-mode
-  . ((go-test-args . "-tags libsqlite3 -timeout 90s")
+((prog-mode
+  . ((go-test-args . "-tags libsqlite3")
      (eval
       . (set
 	 (make-local-variable 'flycheck-go-build-tags)

--- a/app/app.go
+++ b/app/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -17,7 +18,6 @@ import (
 	"github.com/cowsql/go-cowsql/client"
 	"github.com/cowsql/go-cowsql/driver"
 	"github.com/cowsql/go-cowsql/internal/protocol"
-	"github.com/pkg/errors"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -469,8 +469,8 @@ func (a *App) Open(ctx context.Context, database string) (*sql.DB, error) {
 		if err == nil {
 			break
 		}
-		cause := errors.Cause(err)
-		if cause != driver.ErrNoAvailableLeader {
+
+		if !errors.Is(err, driver.ErrNoAvailableLeader) {
 			return nil, err
 		}
 		time.Sleep(time.Second)

--- a/client/client.go
+++ b/client/client.go
@@ -2,9 +2,9 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cowsql/go-cowsql/internal/protocol"
-	"github.com/pkg/errors"
 )
 
 // DialFunc is a function that can be used to establish a network connection.
@@ -50,7 +50,7 @@ func New(ctx context.Context, address string, options ...Option) (*Client, error
 	// Establish the connection.
 	conn, err := o.DialFunc(ctx, address)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to establish network connection")
+		return nil, fmt.Errorf("failed to establish network connection: %w", err)
 	}
 
 	protocol, err := protocol.Handshake(ctx, conn, protocol.VersionOne)
@@ -74,12 +74,12 @@ func (c *Client) Leader(ctx context.Context) (*NodeInfo, error) {
 	protocol.EncodeLeader(&request)
 
 	if err := c.protocol.Call(ctx, &request, &response); err != nil {
-		return nil, errors.Wrap(err, "failed to send Leader request")
+		return nil, fmt.Errorf("failed to send Leader request: %w", err)
 	}
 
 	id, address, err := protocol.DecodeNode(&response)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse Node response")
+		return nil, fmt.Errorf("failed to parse Node response: %w", err)
 	}
 
 	info := &NodeInfo{ID: id, Address: address}
@@ -97,12 +97,12 @@ func (c *Client) Cluster(ctx context.Context) ([]NodeInfo, error) {
 	protocol.EncodeCluster(&request, protocol.ClusterFormatV1)
 
 	if err := c.protocol.Call(ctx, &request, &response); err != nil {
-		return nil, errors.Wrap(err, "failed to send Cluster request")
+		return nil, fmt.Errorf("failed to send Cluster request: %w", err)
 	}
 
 	servers, err := protocol.DecodeNodes(&response)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse Node response")
+		return nil, fmt.Errorf("failed to parse Node response: %w", err)
 	}
 
 	return servers, nil
@@ -127,12 +127,12 @@ func (c *Client) Dump(ctx context.Context, dbname string) ([]File, error) {
 	protocol.EncodeDump(&request, dbname)
 
 	if err := c.protocol.Call(ctx, &request, &response); err != nil {
-		return nil, errors.Wrap(err, "failed to send dump request")
+		return nil, fmt.Errorf("failed to send dump request: %w", err)
 	}
 
 	files, err := protocol.DecodeFiles(&response)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse files response")
+		return nil, fmt.Errorf("failed to parse files response: %w", err)
 	}
 	defer files.Close()
 

--- a/client/no_database_store.go
+++ b/client/no_database_store.go
@@ -5,7 +5,7 @@ package client
 import (
 	"strings"
 
-	"github.com/pkg/errors"
+	"errors"
 )
 
 // DefaultNodeStore creates a new NodeStore using the given filename.

--- a/cmd/cowsql-benchmark/cowsql-benchmark.go
+++ b/cmd/cowsql-benchmark/cowsql-benchmark.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cowsql/go-cowsql/app"
 	"github.com/cowsql/go-cowsql/benchmark"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
 )
@@ -70,8 +69,8 @@ func main() {
 		Long:  docString,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dir := filepath.Join(dir, db)
-			if err := os.MkdirAll(dir, 0755); err != nil {
-				return errors.Wrapf(err, "can't create %s", dir)
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return fmt.Errorf("can't create %s: %w", dir, err)
 			}
 
 			app, err := app.New(dir, app.WithAddress(db), app.WithCluster(*join))
@@ -82,7 +81,7 @@ func main() {
 			readyCtx, cancel := context.WithTimeout(context.Background(), time.Duration(clusterTimeout)*time.Second)
 			defer cancel()
 			if err := app.Ready(readyCtx); err != nil {
-				return errors.Wrap(err, "App not ready in time")
+				return fmt.Errorf("App not ready in time: %w", err)
 			}
 
 			ch := signalChannel()

--- a/cmd/cowsql-demo/cowsql-demo.go
+++ b/cmd/cowsql-demo/cowsql-demo.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cowsql/go-cowsql/app"
 	"github.com/cowsql/go-cowsql/client"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
 )
@@ -39,7 +38,7 @@ Complete documentation is available at https://github.com/cowsql/go-cowsql`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			dir := filepath.Join(dir, db)
 			if err := os.MkdirAll(dir, 0o755); err != nil {
-				return errors.Wrapf(err, "can't create %s", dir)
+				return fmt.Errorf("can't create %s: %w", dir, err)
 			}
 			logFunc := func(l client.LogLevel, format string, a ...interface{}) {
 				if !verbose {

--- a/config.go
+++ b/config.go
@@ -1,3 +1,4 @@
+//go:build !nosqlite3
 // +build !nosqlite3
 
 package cowsql
@@ -8,7 +9,6 @@ import (
 
 	"github.com/cowsql/go-cowsql/internal/bindings"
 	"github.com/cowsql/go-cowsql/internal/protocol"
-	"github.com/pkg/errors"
 )
 
 // ConfigMultiThread sets the threading mode of SQLite to Multi-thread.
@@ -32,7 +32,7 @@ func ConfigMultiThread() error {
 		if err, ok := err.(protocol.Error); ok && err.Code == 21 /* SQLITE_MISUSE */ {
 			return fmt.Errorf("SQLite is already initialized")
 		}
-		return errors.Wrap(err, "unknown error")
+		return fmt.Errorf("unknow error: %w", err)
 	}
 	return nil
 }
@@ -45,6 +45,6 @@ func init() {
 	}
 	err := bindings.ConfigSingleThread()
 	if err != nil {
-		panic(errors.Wrap(err, "set single thread mode"))
+		panic(fmt.Errorf("set single thread mode: %w", err))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/google/renameio v1.0.1
 	github.com/mattn/go-sqlite3 v1.14.7
 	github.com/peterh/liner v1.2.1
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.2.1
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,6 @@ github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/peterh/liner v1.2.1 h1:O4BlKaq/LWu6VRWmol4ByWfzx6MfXc5Op5HETyIy5yg=
 github.com/peterh/liner v1.2.1/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/node.go
+++ b/node.go
@@ -2,11 +2,11 @@ package cowsql
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/cowsql/go-cowsql/client"
 	"github.com/cowsql/go-cowsql/internal/bindings"
-	"github.com/pkg/errors"
 )
 
 // Node runs a cowsql node.
@@ -179,7 +179,7 @@ func (s *Node) Close() error {
 	s.cancel()
 	// Send a stop signal to the cowsql event loop.
 	if err := s.server.Stop(); err != nil {
-		return errors.Wrap(err, "server failed to stop")
+		return fmt.Errorf("server failed to stop: %w", err)
 	}
 
 	s.server.Close()


### PR DESCRIPTION
The package `github.com/pkg/errors` was archived readonly due to the existence of golang native error wrapping. Conventions rules:
1. `import "github.com/pkg/errors"` to `import "errors"`,
2. `errors.Wrap(err, "...")` to `fmt.Errorf("...: %w", err)`,
3. `errors.Cause` to `errors.Is` and `errors.As`.
4. `go-mode` to `prog-mode` since `go-ts-mode` may be used,
5. `-timeout 90s` removed since the timeout may be hit.